### PR TITLE
feat: 테스트 환경에서 저장된 chromaDB의 데이터를 삭제하는 기능 추가

### DIFF
--- a/app/api/v1/controllers/users_post_controller.py
+++ b/app/api/v1/controllers/users_post_controller.py
@@ -8,8 +8,8 @@ from typing import Dict
 
 from fastapi import HTTPException
 
-from app.core.vector_database import list_similarities, list_users
-from app.schemas.user_schema import EmbeddingRegister
+from app.core.vector_database import list_similarities, list_users, reset_collections
+from app.schemas.user_schema import BaseResponse, EmbeddingRegister
 from app.services.users_post_service import register_user
 
 logger = logging.getLogger(__name__)
@@ -37,6 +37,11 @@ async def db_similarity_list():
             "metadatas": (result.get("metadatas", [])),
         },
     }
+
+
+async def db_reset_data():
+    reset_collections()  # 동기 함수이므로 await 필요 없음
+    return BaseResponse(status="success", code="CHROMADB_RESET_SUCCESS")
 
 
 async def create_user(user_data: EmbeddingRegister) -> Dict:

--- a/app/api/v1/endpoints/users_post_router.py
+++ b/app/api/v1/endpoints/users_post_router.py
@@ -46,12 +46,23 @@ class UserPostRouter:
             summary="매칭 스코어 조회(내부 확인용)",
             description="벡터DB-similarity_collection에 등록된 모든 매칭 스코어를 조회합니다.",
         )
+        self.router.add_api_route(
+            "/v1/reset/chromadb",
+            self.db_reset_data,
+            methods=["DELETE"],
+            response_model=BaseResponse,
+            summary="(테스트 환경 리셋을 위한 용도)",
+            description="벡터DB-collection에 저장된 모든 데이터를 초기화 합니다.",
+        )
 
     async def db_user_list(self) -> BaseResponse:
         return await users_post_controller.db_user_list()
 
     async def db_similarity_list(self) -> BaseResponse:
         return await users_post_controller.db_similarity_list()
+
+    async def db_reset_data(self) -> BaseResponse:
+        return await users_post_controller.db_reset_data()
 
     async def create_user(
         self, user_data: EmbeddingRegister = Body(..., description="사용자 등록 데이터")

--- a/app/core/vector_database.py
+++ b/app/core/vector_database.py
@@ -98,6 +98,28 @@ def get_user_data(user_id: str):
     return collection.get(ids=[user_id], include=["metadatas"])
 
 
+def reset_collections():
+    """
+    크로마DB 컬렉션 완전 삭제 및 재생성
+    """
+    try:
+        client = get_chroma_client()
+
+        # 컬렉션 삭제
+        client.delete_collection("user_profiles")
+        client.delete_collection("user_similarities")
+
+        # 컬렉션 재생성
+        global user_collection, similarity_collection
+        user_collection = client.get_or_create_collection("user_profiles")
+        similarity_collection = client.get_or_create_collection("user_similarities")
+
+        print("[ChromaDB] 컬렉션 재생성 완료")
+
+    except Exception as e:
+        raise RuntimeError(f"ChromaDB 컬렉션 초기화 실패: {e}")
+
+
 async def get_users_data(user_ids: list[str]):
     collection = get_user_collection()
     return collection.get(ids=user_ids, include=["metadatas"])


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

ChromaDB 서버 모드 환경에서도 컬렉션 데이터를 완전히 초기화할 수 있도록 reset_collections() 함수를 추가했습니다.
이 함수는 user_profiles 및 user_similarities 컬렉션을 삭제한 뒤 동일한 이름으로 다시 생성하며, 테스트 초기화나 데이터 클린업 목적에 활용될 수 있습니다.

- get_chroma_client()를 통해 서버 모드에서도 정상 작동

- FastAPI API 또는 테스트 코드에서 직접 호출 가능


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 참고 자료 / 스크린샷 (선택)
<img width="1433" alt="스크린샷 2025-05-09 11 49 57" src="https://github.com/user-attachments/assets/f59ea437-244f-4971-9a4c-9a5728802cf9" />

## 💬 공유사항 to 리뷰어

테스트 후 정상 작동동 확인하였습니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)
