### PR TITLE
feat: 유사도 재계산 스크립트 추가(#230)

### DIFF
--- a/app-tuning/scripts/recompute_all_similarities.py
+++ b/app-tuning/scripts/recompute_all_similarities.py
@@ -1,0 +1,95 @@
+import traceback
+
+from core.matching_score_by_category import compute_matching_score
+from core.vector_database import get_user_collection
+from fastapi import HTTPException
+from services.user_service import upsert_similarity_v3
+from utils.logger import log_performance, logger
+
+# SIM_COLLECTIONS = {"friend": "friend_similarities", "couple": "couple_similarities"} # get_similarity_collection 등으로 대체
+
+
+def get_all_user_ids():
+    data = get_user_collection().get(include=[])
+    return data["ids"]
+
+
+def recompute_all_similarities(mode: str):
+    """
+    모든 유저 데이터를 한 번만 로드하여 유사도를 재계산합니다.
+    """
+    print(f"✅ Recomputing {mode} similarities...")
+
+    # 1. 성능 개선: 모든 유저 정보를 한 번만 가져옵니다.
+    try:
+        all_users = get_user_collection().get(include=["embeddings", "metadatas"])
+    except Exception as e:
+        print(f"[ERROR] Failed to fetch all users: {e}")
+        return
+
+    user_ids = all_users["ids"]
+
+    for user_id in user_ids:
+        try:
+            # 2. 개선: all_users 데이터를 파라미터로 전달합니다.
+            result = update_similarity_for_single_user(
+                user_id=user_id, category=mode, all_users_data=all_users
+            )
+            print(
+                f"[{mode.upper()}] Updated: {user_id} with {result['updated_similarities']} matches"
+            )
+        except Exception as e:
+            print(f"[ERROR] {mode} similarity failed for {user_id}: {e}")
+            traceback.print_exc()
+
+
+@log_performance(
+    operation_name="update_similarity_for_single_user", include_memory=True
+)
+def update_similarity_for_single_user(
+    user_id: str, category: str, all_users_data: dict
+) -> dict:
+    """
+    단일 유저에 대해 다른 모든 유저와의 유사도를 계산하고 저장합니다. (단방향)
+    """
+    try:
+        ids = all_users_data["ids"]
+        if user_id not in ids:
+            # 에러 처리는 기존과 같이 유지
+            raise HTTPException(status_code=404, detail=...)
+
+        idx = ids.index(user_id)
+        user_embedding, user_meta = (
+            all_users_data["embeddings"][idx],
+            all_users_data["metadatas"][idx],
+        )
+
+        # 3. 로직 단순화: 정방향 계산만 수행합니다.
+        similarities = compute_matching_score(
+            user_id=user_id,
+            user_embedding=user_embedding,
+            user_meta=user_meta,
+            all_users=all_users_data,
+            category=category,  # <--- 이 라인을 추가하세요
+        )
+
+        # 4. 단순화 및 수정: `category`를 사용해 해당 컬렉션에 한 번만 저장합니다.
+        upsert_similarity_v3(
+            user_id=user_id,
+            embedding=user_embedding,
+            similarities=similarities,
+            category=category,
+        )
+
+        return {"userId": user_id, "updated_similarities": len(similarities)}
+
+    except Exception as e:
+        # 에러 처리는 기존과 같이 유지
+        print(f"[SIMILARITY_UPDATE_ERROR] {e}")
+        raise HTTPException(status_code=500, detail=...)
+
+
+if __name__ == "__main__":
+    recompute_all_similarities("friend")
+    recompute_all_similarities("couple")
+    logger.info("🎉 All similarity recomputations completed.")


### PR DESCRIPTION
## #️⃣ Issue Number

#230

## 📝 요약(Summary)


카테고리 기반 전체 유저 유사도 재계산 기능을 추가했습니다.  
한 번에 전체 유저 데이터를 가져와 반복 호출 없이 성능을 개선하고, `category`를 기반으로 각 유저에 대해 유사도를 계산 및 저장합니다.

- `friend`, `couple` 등 category 분기 적용
- 로그 및 예외처리


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 참고 자료 / 스크린샷 (선택)

## 💬 공유사항 to 리뷰어

3차 배포 적용시 카테고리 매칭 추천 사전 계산을 위한 스크립트입니다. 
서버 첫 배포 시에 한 번만 실행해주시면 됩니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)
