### PR TITLE
fix: 동기 서비스 호출 시 이벤트 루프 블로킹 방지

### DIFF
--- a/app-report/api/controllers/tuning_report_controller.py
+++ b/app-report/api/controllers/tuning_report_controller.py
@@ -1,6 +1,7 @@
 # 튜닝리포트(뉴스) 생성 컨트롤러
 
 from fastapi import HTTPException
+from starlette.concurrency import run_in_threadpool
 
 from ...schemas.tuning_schema import TuningReport, TuningReportResponse
 from ...services.tuning_report_service_gcp_prod import generate_tuning_report_with_agent
@@ -9,7 +10,7 @@ from ...services.tuning_report_service_gcp_prod import generate_tuning_report_wi
 async def create_tuning_report(users_data: TuningReport) -> TuningReportResponse:
     try:
         # 멀티에이전트
-        result = await generate_tuning_report_with_agent(users_data)
+        result = await run_in_threadpool(generate_tuning_report_with_agent, users_data)
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 비동기 API 엔드포인트에서 동기 함수인 튜닝 리포트 생성 서비스를 직접 호출하여, FastAPI의 메인 이벤트 루프가 블로킹될 수 있는 문제 해결
- `run_in_threadpool()` 함수를 통해 동기 함수를 별도의 스레드에서 실행하도록 변경

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 참고 자료 / 스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)
